### PR TITLE
wait for kairos to poweroff instead of on a file

### DIFF
--- a/builder/builds.pkr.hcl
+++ b/builder/builds.pkr.hcl
@@ -2,8 +2,9 @@ build {
   name = "img"
   sources = ["source.qemu.stylus"]
   provisioner "shell" {
-    environment_vars = ["FILE=/var/run/.stylus-installed"]
     scripts = ["${path.root}/scripts/wait.sh"]
+    expect_disconnect = true
+    skip_clean = true
   }
 }
 
@@ -11,8 +12,9 @@ build {
   name = "vmdk"
   sources = ["source.qemu.stylus"]
   provisioner "shell" {
-    environment_vars = ["FILE=/var/run/.stylus-installed"]
     scripts = ["${path.root}/scripts/wait.sh"]
+    expect_disconnect = true
+    skip_clean = true
   }
   post-processor "shell-local" {
     environment_vars = ["CWD=${path.cwd}"]
@@ -24,8 +26,9 @@ build {
   name = "qcow2"
   sources = ["source.qemu.stylus"]
   provisioner "shell" {
-    environment_vars = ["FILE=/var/run/.stylus-installed"]
     scripts = ["${path.root}/scripts/wait.sh"]
+    expect_disconnect = true
+    skip_clean = true
   }
   post-processor "shell-local" {
     environment_vars = ["CWD=${path.cwd}"]
@@ -38,8 +41,9 @@ build {
   name = "iso"
   sources = ["source.qemu.stylus"]
   provisioner "shell" {
-    environment_vars = ["FILE=/var/run/.stylus-installed"]
     scripts = ["${path.root}/scripts/wait.sh"]
+    expect_disconnect = true
+    skip_clean = true
   }
   post-processor "shell-local" {
     environment_vars = ["CWD=${path.cwd}"]

--- a/builder/scripts/wait.sh
+++ b/builder/scripts/wait.sh
@@ -1,3 +1,6 @@
-#!/usr/bin/env bash
-echo "Waiting for file $FILE"
-while [ ! -f "$FILE" ]; do sleep 2; done;
+#!/bin/bash
+
+echo "waiting for poweroff"
+while true; do
+  sleep 2
+done

--- a/user-data
+++ b/user-data
@@ -1,6 +1,6 @@
 install:
   reboot: false
-  poweroff: false
+  poweroff: true
 stylus:
   trace: true
   site:
@@ -13,11 +13,6 @@ stages:
       if: '[ -f "/run/cos/live_mode" ]'
       commands:
       - echo -n > /etc/machine-id
-  after-install.after:
-    - files:
-        - path: /var/run/.stylus-installed
-          content: ""
-          permissions: 0777
   initramfs:
     - users:
         kairos:


### PR DESCRIPTION
expect_disconnect allows packer to not error out once ssh connection killed by kairos poweroff
without skip_clean seems packer will try to reconnect

tested couple of times works fine, vmdk boots into registration mode